### PR TITLE
PS2Event should always contain a world_id

### DIFF
--- a/src/client/events/AchievementEarned.ts
+++ b/src/client/events/AchievementEarned.ts
@@ -9,7 +9,6 @@ export default class AchievementEarned extends PS2Event implements AchievementEa
     public readonly character_id: string;
     public readonly event_name: 'AchievementEarned';
     public readonly timestamp: string;
-    public readonly world_id: string;
     public readonly zone_id: string;
 
     public toHash(): string {

--- a/src/client/events/BattleRankUp.ts
+++ b/src/client/events/BattleRankUp.ts
@@ -9,7 +9,6 @@ export default class BattleRankUp extends PS2Event implements BattleRankUpData {
     public readonly character_id: string;
     public readonly event_name: 'BattleRankUp';
     public readonly timestamp: string;
-    public readonly world_id: string;
     public readonly zone_id: string;
 
     public toHash(): string {

--- a/src/client/events/ContinentLock.ts
+++ b/src/client/events/ContinentLock.ts
@@ -14,7 +14,6 @@ export default class ContinentLock extends PS2Event implements ContinentLockData
     public tr_population: string;
     public triggering_faction: string;
     public vs_population: string;
-    public world_id: string;
     public zone_id: string;
 
     public toHash(): string {

--- a/src/client/events/ContinentUnlock.ts
+++ b/src/client/events/ContinentUnlock.ts
@@ -14,7 +14,6 @@ export default class ContinentUnlock extends PS2Event implements ContinentUnlock
     public tr_population: string;
     public triggering_faction: string;
     public vs_population: string;
-    public world_id: string;
     public zone_id: string;
 
     public toHash(): string {

--- a/src/client/events/Death.ts
+++ b/src/client/events/Death.ts
@@ -15,7 +15,6 @@ export default class Death extends PS2Event implements DeathData {
     public readonly event_name: 'Death';
     public readonly is_headshot: string;
     public readonly timestamp: string;
-    public readonly world_id: string;
     public readonly zone_id: string;
 
     public toHash(): string {

--- a/src/client/events/FacilityControl.ts
+++ b/src/client/events/FacilityControl.ts
@@ -12,7 +12,6 @@ export default class FacilityControl extends PS2Event implements FacilityControl
     public readonly old_faction_id: string;
     public readonly outfit_id: string;
     public readonly timestamp: string;
-    public readonly world_id: string;
     public readonly zone_id: string;
 
     public toHash(): string {

--- a/src/client/events/GainExperience.ts
+++ b/src/client/events/GainExperience.ts
@@ -12,7 +12,6 @@ export default class GainExperience extends PS2Event implements GainExperienceDa
     public readonly loadout_id: string;
     public readonly other_id: string;
     public readonly timestamp: string;
-    public readonly world_id: string;
     public readonly zone_id: string;
 
     public toHash(): string {

--- a/src/client/events/ItemAdded.ts
+++ b/src/client/events/ItemAdded.ts
@@ -11,7 +11,6 @@ export default class ItemAdded extends PS2Event implements ItemAddedData {
     public readonly item_count: string;
     public readonly item_id: string;
     public readonly timestamp: string;
-    public readonly world_id: string;
     public readonly zone_id: string;
 
     public toHash(): string {

--- a/src/client/events/MetagameEvent.ts
+++ b/src/client/events/MetagameEvent.ts
@@ -14,7 +14,6 @@ export default class MetagameEvent extends PS2Event implements MetagameEventData
     public readonly metagame_event_state: string;
     public readonly metagame_event_state_name: string;
     public readonly timestamp: string;
-    public readonly world_id: string;
     public readonly instance_id: string;
 
     public toHash(): string {

--- a/src/client/events/PS2Event.ts
+++ b/src/client/events/PS2Event.ts
@@ -7,6 +7,7 @@ export default abstract class PS2Event {
 
     public readonly event_name: string;
     public readonly timestamp: string;
+    public readonly world_id: string;
 
     /**
      *

--- a/src/client/events/PlayerFacilityCapture.ts
+++ b/src/client/events/PlayerFacilityCapture.ts
@@ -10,7 +10,6 @@ export default class PlayerFacilityCapture extends PS2Event implements PlayerFac
     public readonly facility_id: string;
     public readonly outfit_id: string;
     public readonly timestamp: string;
-    public readonly world_id: string;
     public readonly zone_id: string;
 
     public toHash(): string {

--- a/src/client/events/PlayerFacilityDefend.ts
+++ b/src/client/events/PlayerFacilityDefend.ts
@@ -10,7 +10,6 @@ export default class PlayerFacilityDefend extends PS2Event implements PlayerFaci
     public readonly facility_id: string;
     public readonly outfit_id: string;
     public readonly timestamp: string;
-    public readonly world_id: string;
     public readonly zone_id: string;
 
     public toHash(): string {

--- a/src/client/events/PlayerLogin.ts
+++ b/src/client/events/PlayerLogin.ts
@@ -8,7 +8,6 @@ export default class PlayerLogin extends PS2Event implements PlayerLoginData {
     public readonly character_id: string;
     public readonly event_name: 'PlayerLogin';
     public readonly timestamp: string;
-    public readonly world_id: string;
 
     public toHash(): string {
         return `PlayerLogin:${this.character_id}:${this.timestamp}`;

--- a/src/client/events/PlayerLogout.ts
+++ b/src/client/events/PlayerLogout.ts
@@ -8,7 +8,6 @@ export default class PlayerLogout extends PS2Event implements PlayerLogoutData {
     public readonly character_id: string;
     public readonly event_name: 'PlayerLogout';
     public readonly timestamp: string;
-    public readonly world_id: string;
 
     public toHash(): string {
         return `PlayerLogout:${this.character_id}:${this.timestamp}`;

--- a/src/client/events/SkillAdded.ts
+++ b/src/client/events/SkillAdded.ts
@@ -9,7 +9,6 @@ export default class SkillAdded extends PS2Event implements SkillAddedData {
     public readonly event_name: 'SkillAdded';
     public readonly skill_id: string;
     public readonly timestamp: string;
-    public readonly world_id: string;
     public readonly zone_id: string;
 
     public toHash(): string {

--- a/src/client/events/VehicleDestroy.ts
+++ b/src/client/events/VehicleDestroy.ts
@@ -15,7 +15,6 @@ export default class VehicleDestroy extends PS2Event implements VehicleDestroyDa
     public readonly faction_id: string;
     public readonly timestamp: string;
     public readonly vehicle_id: string;
-    public readonly world_id: string;
     public readonly zone_id: string;
 
     public toHash(): string {


### PR DESCRIPTION
Move world_id to PS2Events

Fixes #14 