### PR TITLE
feat(client): added subscription verify logic

### DIFF
--- a/src/client/census.client.ts
+++ b/src/client/census.client.ts
@@ -151,6 +151,15 @@ export class CensusClient extends EventEmitter<ClientEvents> {
   }
 
   /**
+   * Verifies if the subscription matches with what is expected
+   *
+   * @return {Promise<boolean>} whether the subscription is correct
+   */
+  verifySubscription(): Promise<boolean> {
+    return this.streamManager.subscriptionManager.verifySubscription();
+  }
+
+  /**
    * Get all the recent character ids
    *
    * @return {Promise<string[]>} the list of character ids

--- a/src/client/subscription.manager.ts
+++ b/src/client/subscription.manager.ts
@@ -122,6 +122,41 @@ export class SubscriptionManager {
   }
 
   /**
+   * Verifies if the subscription matches with what is expected
+   *
+   * @return {Promise<boolean>} whether the subscription is correct
+   */
+  async verifySubscription(): Promise<boolean> {
+    const subscription = await this.commandHandler.subscribe({});
+
+    if (
+      this.logicalAndCharactersWithWorlds !=
+      subscription.logicalAndCharactersWithWorlds
+    )
+      return false;
+
+    if (this.characters.has('all')) {
+      if (!('characters' in subscription)) return false;
+    } else {
+      if (
+        !('characterCount' in subscription) ||
+        subscription.characterCount != this.characters.size
+      )
+        return false;
+    }
+
+    for (const world of this.worlds) {
+      if (!subscription.worlds.some(id => world == id)) return false;
+    }
+
+    for (const event of this.eventNames) {
+      if (!subscription.eventNames.some(name => event == name)) return false;
+    }
+
+    return true;
+  }
+
+  /**
    * Rerun all subscriptions
    *
    * @param {boolean} reset When true unsubscribes from all events first


### PR DESCRIPTION
Echoes the subscription from Census and compares it to what we expect as stored in the `SubscriptionManager` based on historic subscriptions.