### PR TITLE
Feat/improved event types

### DIFF
--- a/src/client/census.client.ts
+++ b/src/client/census.client.ts
@@ -5,7 +5,7 @@ import { RestClient, RestClientOptions } from '../rest/rest.client';
 import { CharacterManager, CharacterManagerOptions } from './managers';
 import {
   AchievementEarned,
-  BattleRankUpEvent,
+  BattleRankUp,
   ContinentLock,
   Death,
   FacilityControl,
@@ -35,12 +35,12 @@ export type ClientEvents = {
   error: (err: Error) => void;
   warn: (err: Error) => void;
   debug: (info: string) => void;
-  duplicate: (event: PS2Event) => void;
+  duplicate: (event: PS2Event<any>) => void;
   subscribed: (subscription: EventSubscribed) => void;
   serviceState: (worldId: string, online: boolean, detail: string) => void;
-  ps2Event: (event: PS2Event) => void;
+  ps2Event: (event: PS2Event<any>) => void;
   achievementEarned: (event: AchievementEarned) => void;
-  battleRankUp: (event: BattleRankUpEvent) => void;
+  battleRankUp: (event: BattleRankUp) => void;
   death: (event: Death) => void;
   gainExperience: (event: GainExperience) => void;
   itemAdded: (event: ItemAdded) => void;

--- a/src/client/concerns/stream-filter.contract.ts
+++ b/src/client/concerns/stream-filter.contract.ts
@@ -1,5 +1,5 @@
 import { PS2Event } from '../events/base/ps2.event';
 
 export interface StreamFilterContract {
-  filter(event: PS2Event): boolean;
+  filter(event: PS2Event<any>): boolean;
 }

--- a/src/client/constants/ps2.constants.ts
+++ b/src/client/constants/ps2.constants.ts
@@ -1,7 +1,8 @@
 export enum Faction {
+  NONE = '0',
+  VS = '1',
   NC = '2',
   TR = '3',
-  VS = '1',
   NSO = '4',
 }
 

--- a/src/client/constants/ps2.constants.ts
+++ b/src/client/constants/ps2.constants.ts
@@ -15,12 +15,6 @@ export enum Loadout {
   MAX,
 }
 
-export const factionMap = new Map<string, Faction>([
-  ['1', Faction.VS],
-  ['2', Faction.NC],
-  ['3', Faction.TR],
-]);
-
 export const loadoutFactionMap = new Map<string, Faction>([
   ['1', Faction.NC],
   ['3', Faction.NC],

--- a/src/client/events/achievement-earned.event.ts
+++ b/src/client/events/achievement-earned.event.ts
@@ -1,6 +1,7 @@
 import { CharacterEvent } from './base/character.event';
+import { PS2Events } from '../../stream';
 
-export class AchievementEarned extends CharacterEvent {
+export class AchievementEarned extends CharacterEvent<PS2Events.AchievementEarned> {
   readonly emit = 'achievementEarned';
 
   readonly achievement_id: string;

--- a/src/client/events/base/attacker.event.ts
+++ b/src/client/events/base/attacker.event.ts
@@ -1,22 +1,31 @@
-import { CharacterEvent } from './character.event';
+import { CharacterEvent, CharacterEventPayload } from './character.event';
 import {
   Faction,
-  factionMap,
   Loadout,
   loadoutFactionMap,
   loadoutTypeMap,
 } from '../../constants';
-import { PS2Event as PS2EventPayload } from '../../../stream';
+
+export type AttackerEventPayload = Extract<
+  CharacterEventPayload,
+  {
+    attacker_character_id: string;
+    attacker_team_id: string;
+    attacker_loadout_id: string;
+    attacker_vehicle_id: string;
+    attacker_weapon_id: string;
+    team_id: string;
+  }
+>;
 
 export abstract class AttackerEvent<
-  T extends PS2EventPayload,
+  T extends AttackerEventPayload,
 > extends CharacterEvent<T> {
   /**
    * Can be overwritten if necessary
    */
   static loadoutFactionMap = loadoutFactionMap;
   static loadoutTypeMap = loadoutTypeMap;
-  static factionMap = factionMap;
 
   readonly attacker_character_id: string;
   readonly attacker_team_id: Faction;
@@ -37,37 +46,15 @@ export abstract class AttackerEvent<
   }
 
   /**
-   * Team the attacker belongs to
-   *
-   * @return {Faction}
-   */
-  get attacker_team(): Faction {
-    const team = AttackerEvent.factionMap.get(this.attacker_team_id);
-
-    if (team === undefined)
-      throw new TypeError(
-        `Unknown attacker_team_id when determining team: ${this.attacker_team_id}`,
-      );
-
-    return team;
-  }
-
-  /**
    * Faction of the attacker
    *
    * @return {Faction}
    */
   get attacker_faction(): Faction {
-    const faction = AttackerEvent.loadoutFactionMap.get(
-      this.attacker_loadout_id,
+    return (
+      AttackerEvent.loadoutFactionMap.get(this.attacker_loadout_id) ??
+      Faction.NONE
     );
-
-    if (faction === undefined)
-      throw new TypeError(
-        `Unknown attacker_loadout_id when determining faction: ${this.attacker_loadout_id}`,
-      );
-
-    return faction;
   }
 
   /**
@@ -84,21 +71,5 @@ export abstract class AttackerEvent<
       );
 
     return loadout;
-  }
-
-  /**
-   * Team the victim belongs to
-   *
-   * @return {Faction}
-   */
-  get team(): Faction {
-    const team = AttackerEvent.factionMap.get(this.team_id);
-
-    if (team === undefined)
-      throw new TypeError(
-        `Unknown team_id when determining team: ${this.team_id}`,
-      );
-
-    return team;
   }
 }

--- a/src/client/events/base/attacker.event.ts
+++ b/src/client/events/base/attacker.event.ts
@@ -6,8 +6,11 @@ import {
   loadoutFactionMap,
   loadoutTypeMap,
 } from '../../constants';
+import { PS2Event as PS2EventPayload } from '../../../stream';
 
-export abstract class AttackerEvent extends CharacterEvent {
+export abstract class AttackerEvent<
+  T extends PS2EventPayload,
+> extends CharacterEvent<T> {
   /**
    * Can be overwritten if necessary
    */
@@ -16,11 +19,11 @@ export abstract class AttackerEvent extends CharacterEvent {
   static factionMap = factionMap;
 
   readonly attacker_character_id: string;
-  readonly attacker_team_id: string;
+  readonly attacker_team_id: Faction;
   readonly attacker_loadout_id: string;
   readonly attacker_vehicle_id: string;
   readonly attacker_weapon_id: string;
-  readonly team_id: string;
+  readonly team_id: Faction;
 
   /**
    * Fetch the character data from the attacker

--- a/src/client/events/base/character-world.event.ts
+++ b/src/client/events/base/character-world.event.ts
@@ -1,8 +1,13 @@
 import { PS2Event } from './ps2.event';
 import { PS2Event as PS2EventPayload } from '../../../stream';
 
+export type CharacterWorldEventPayload = Extract<
+  PS2EventPayload,
+  { character_id: string }
+>;
+
 export abstract class CharacterWorldEvent<
-  T extends PS2EventPayload,
+  T extends CharacterWorldEventPayload,
 > extends PS2Event<T> {
   readonly character_id: string;
 

--- a/src/client/events/base/character-world.event.ts
+++ b/src/client/events/base/character-world.event.ts
@@ -1,6 +1,9 @@
 import { PS2Event } from './ps2.event';
+import { PS2Event as PS2EventPayload } from '../../../stream';
 
-export abstract class CharacterWorldEvent extends PS2Event {
+export abstract class CharacterWorldEvent<
+  T extends PS2EventPayload,
+> extends PS2Event<T> {
   readonly character_id: string;
 
   /**

--- a/src/client/events/base/character.event.ts
+++ b/src/client/events/base/character.event.ts
@@ -1,6 +1,9 @@
 import { ZoneEvent } from './zone.event';
+import { PS2Event as PS2EventPayload } from '../../../stream';
 
-export abstract class CharacterEvent extends ZoneEvent {
+export abstract class CharacterEvent<
+  T extends PS2EventPayload,
+> extends ZoneEvent<T> {
   readonly character_id: string;
 
   /**

--- a/src/client/events/base/character.event.ts
+++ b/src/client/events/base/character.event.ts
@@ -1,8 +1,12 @@
-import { ZoneEvent } from './zone.event';
-import { PS2Event as PS2EventPayload } from '../../../stream';
+import { ZoneEvent, ZoneEventPayload } from './zone.event';
+
+export type CharacterEventPayload = Extract<
+  ZoneEventPayload,
+  { character_id: string }
+>;
 
 export abstract class CharacterEvent<
-  T extends PS2EventPayload,
+  T extends CharacterEventPayload,
 > extends ZoneEvent<T> {
   readonly character_id: string;
 

--- a/src/client/events/base/ps2.event.ts
+++ b/src/client/events/base/ps2.event.ts
@@ -3,9 +3,11 @@ import { PS2Event as PS2EventPayload } from '../../../stream/types/ps2.events';
 import { unixToDate } from '../../../utils/formatters';
 
 export abstract class PS2Event<T extends PS2EventPayload> {
+  protected static readonly DATA = 1;
+
   readonly emit: keyof ClientEvents;
 
-  readonly event_name: string;
+  readonly event_name: T['event_name'];
   readonly timestamp: Date;
   readonly world_id: string;
 
@@ -14,27 +16,7 @@ export abstract class PS2Event<T extends PS2EventPayload> {
    * @param {PS2Event} raw
    */
   constructor(protected readonly client: CensusClient, readonly raw: T) {
-    this.hydrateObject(raw);
-  }
-
-  /**
-   * @param {PS2Event} data
-   * @private
-   */
-  private hydrateObject(data: T) {
-    Object.assign(this, data, { timestamp: unixToDate(data.timestamp) });
-
-    this.cast(data);
-  }
-
-  /**
-   * Cast additional to formats
-   *
-   * @param data
-   * @protected
-   */
-  protected cast(data: T): void {
-    // void
+    Object.assign(this, raw, { timestamp: unixToDate(raw.timestamp) });
   }
 
   /**

--- a/src/client/events/base/ps2.event.ts
+++ b/src/client/events/base/ps2.event.ts
@@ -2,7 +2,7 @@ import { CensusClient, ClientEvents } from '../../census.client';
 import { PS2Event as PS2EventPayload } from '../../../stream/types/ps2.events';
 import { unixToDate } from '../../../utils/formatters';
 
-export abstract class PS2Event<T extends PS2EventPayload = PS2EventPayload> {
+export abstract class PS2Event<T extends PS2EventPayload> {
   readonly emit: keyof ClientEvents;
 
   readonly event_name: string;

--- a/src/client/events/base/world.event.ts
+++ b/src/client/events/base/world.event.ts
@@ -1,6 +1,5 @@
-import { ZoneEvent } from './zone.event';
-import { PS2Event as PS2EventPayload } from '../../../stream';
+import { ZoneEvent, ZoneEventPayload } from './zone.event';
 
 export abstract class WorldEvent<
-  T extends PS2EventPayload,
+  T extends ZoneEventPayload,
 > extends ZoneEvent<T> {}

--- a/src/client/events/base/world.event.ts
+++ b/src/client/events/base/world.event.ts
@@ -1,3 +1,6 @@
 import { ZoneEvent } from './zone.event';
+import { PS2Event as PS2EventPayload } from '../../../stream';
 
-export abstract class WorldEvent extends ZoneEvent {}
+export abstract class WorldEvent<
+  T extends PS2EventPayload,
+> extends ZoneEvent<T> {}

--- a/src/client/events/base/zone.event.ts
+++ b/src/client/events/base/zone.event.ts
@@ -1,7 +1,11 @@
 import { PS2Event } from './ps2.event';
 import { PS2Event as PS2EventPayload } from '../../../stream';
 
-export abstract class ZoneEvent<T extends PS2EventPayload> extends PS2Event<T> {
+export type ZoneEventPayload = Extract<PS2EventPayload, { zone_id: string }>;
+
+export abstract class ZoneEvent<
+  T extends ZoneEventPayload,
+> extends PS2Event<T> {
   readonly zone_id: string;
 
   get zoneDefinitionId(): number {

--- a/src/client/events/base/zone.event.ts
+++ b/src/client/events/base/zone.event.ts
@@ -1,6 +1,7 @@
 import { PS2Event } from './ps2.event';
+import { PS2Event as PS2EventPayload } from '../../../stream';
 
-export abstract class ZoneEvent extends PS2Event {
+export abstract class ZoneEvent<T extends PS2EventPayload> extends PS2Event<T> {
   readonly zone_id: string;
 
   get zoneDefinitionId(): number {

--- a/src/client/events/battle-rank-up.event.ts
+++ b/src/client/events/battle-rank-up.event.ts
@@ -1,6 +1,7 @@
 import { CharacterEvent } from './base/character.event';
+import { PS2Events } from '../../stream';
 
-export class BattleRankUpEvent extends CharacterEvent {
+export class BattleRankUpEvent extends CharacterEvent<PS2Events.BattleRankUp> {
   readonly emit = 'battleRankUp';
 
   readonly battle_rank: string;

--- a/src/client/events/battle-rank-up.event.ts
+++ b/src/client/events/battle-rank-up.event.ts
@@ -1,11 +1,23 @@
 import { CharacterEvent } from './base/character.event';
 import { PS2Events } from '../../stream';
+import { PS2Event } from './base/ps2.event';
 
-export class BattleRankUpEvent extends CharacterEvent<PS2Events.BattleRankUp> {
+export class BattleRankUp extends CharacterEvent<PS2Events.BattleRankUp> {
   readonly emit = 'battleRankUp';
 
-  readonly battle_rank: string;
+  readonly battle_rank: number;
   readonly event_name: 'BattleRankUp';
+
+  constructor(
+    ...params: ConstructorParameters<typeof PS2Event<PS2Events.BattleRankUp>>
+  ) {
+    super(...params);
+
+    this.battle_rank = Number.parseInt(
+      params[BattleRankUp.DATA].battle_rank,
+      10,
+    );
+  }
 
   toHash(): string {
     return `BattleRankUp:${this.character_id}:${this.timestamp}:${this.battle_rank}`;

--- a/src/client/events/continent-lock.event.ts
+++ b/src/client/events/continent-lock.event.ts
@@ -1,6 +1,7 @@
 import { WorldEvent } from './base/world.event';
+import { PS2Events } from '../../stream';
 
-export class ContinentLock extends WorldEvent {
+export class ContinentLock extends WorldEvent<PS2Events.ContinentLock> {
   readonly emit = 'continentLock';
 
   event_name: 'ContinentLock';

--- a/src/client/events/continent-lock.event.ts
+++ b/src/client/events/continent-lock.event.ts
@@ -1,17 +1,35 @@
 import { WorldEvent } from './base/world.event';
 import { PS2Events } from '../../stream';
+import { Faction } from '../constants';
+import { PS2Event } from './base/ps2.event';
 
 export class ContinentLock extends WorldEvent<PS2Events.ContinentLock> {
   readonly emit = 'continentLock';
 
-  event_name: 'ContinentLock';
-  event_type: string;
-  metagame_event_id: string;
-  nc_population: string;
-  previous_faction: string;
-  tr_population: string;
-  triggering_faction: string;
-  vs_population: string;
+  readonly event_name: 'ContinentLock';
+  readonly event_type: string;
+  readonly metagame_event_id: string;
+  readonly nc_population: number;
+  readonly tr_population: number;
+  readonly vs_population: number;
+  readonly previous_faction: Faction;
+  readonly triggering_faction: Faction;
+
+  constructor(
+    ...params: ConstructorParameters<typeof PS2Event<PS2Events.ContinentLock>>
+  ) {
+    super(...params);
+
+    this.nc_population = Number.parseFloat(
+      params[ContinentLock.DATA].nc_population,
+    );
+    this.tr_population = Number.parseFloat(
+      params[ContinentLock.DATA].tr_population,
+    );
+    this.vs_population = Number.parseFloat(
+      params[ContinentLock.DATA].vs_population,
+    );
+  }
 
   toHash(): string {
     return `ContinentLock:${this.world_id}:${this.zone_id}:${this.timestamp}`;

--- a/src/client/events/continent-unlock.event.ts
+++ b/src/client/events/continent-unlock.event.ts
@@ -1,6 +1,7 @@
 import { WorldEvent } from './base/world.event';
+import { PS2Events } from '../../stream';
 
-export class ContinentUnlock extends WorldEvent {
+export class ContinentUnlock extends WorldEvent<PS2Events.ContinentUnlock> {
   readonly emit = 'continentUnlock';
 
   event_name: 'ContinentUnlock';

--- a/src/client/events/continent-unlock.event.ts
+++ b/src/client/events/continent-unlock.event.ts
@@ -1,5 +1,7 @@
 import { WorldEvent } from './base/world.event';
 import { PS2Events } from '../../stream';
+import { Faction } from '../constants';
+import { PS2Event } from './base/ps2.event';
 
 export class ContinentUnlock extends WorldEvent<PS2Events.ContinentUnlock> {
   readonly emit = 'continentUnlock';
@@ -7,11 +9,27 @@ export class ContinentUnlock extends WorldEvent<PS2Events.ContinentUnlock> {
   event_name: 'ContinentUnlock';
   event_type: string;
   metagame_event_id: string;
-  nc_population: string;
-  previous_faction: string;
-  tr_population: string;
-  triggering_faction: string;
-  vs_population: string;
+  nc_population: number;
+  tr_population: number;
+  vs_population: number;
+  previous_faction: Faction;
+  triggering_faction: Faction;
+
+  constructor(
+    ...params: ConstructorParameters<typeof PS2Event<PS2Events.ContinentUnlock>>
+  ) {
+    super(...params);
+
+    this.nc_population = Number.parseFloat(
+      params[ContinentUnlock.DATA].nc_population,
+    );
+    this.tr_population = Number.parseFloat(
+      params[ContinentUnlock.DATA].tr_population,
+    );
+    this.vs_population = Number.parseFloat(
+      params[ContinentUnlock.DATA].vs_population,
+    );
+  }
 
   toHash(): string {
     return `ContinentUnlock:${this.world_id}:${this.zone_id}:${this.timestamp}`;

--- a/src/client/events/death.event.ts
+++ b/src/client/events/death.event.ts
@@ -11,7 +11,7 @@ export enum Kill {
   RestrictedArea,
 }
 
-export class Death extends AttackerEvent {
+export class Death extends AttackerEvent<PS2Events.Death> {
   readonly emit = 'death';
 
   readonly attacker_fire_mode_id: string;
@@ -26,8 +26,8 @@ export class Death extends AttackerEvent {
    * @protected
    */
   protected cast(data: DeathPayload) {
-    (this as any)['is_headshot'] = numberStringToBoolean(data.is_headshot);
-    (this as any)['is_critical'] = numberStringToBoolean(data.is_critical);
+    (this as any).is_headshot = numberStringToBoolean(data.is_headshot);
+    (this as any).is_critical = numberStringToBoolean(data.is_critical);
   }
 
   /**

--- a/src/client/events/death.event.ts
+++ b/src/client/events/death.event.ts
@@ -2,7 +2,7 @@ import { Faction, Loadout } from '../constants/ps2.constants';
 import { PS2Events } from '../../stream/types/ps2.events';
 import { numberStringToBoolean } from '../../utils/formatters';
 import { AttackerEvent } from './base/attacker.event';
-import DeathPayload = PS2Events.Death;
+import { PS2Event } from './base/ps2.event';
 
 export enum Kill {
   Normal,
@@ -20,14 +20,13 @@ export class Death extends AttackerEvent<PS2Events.Death> {
   readonly is_headshot: boolean;
   readonly is_critical: boolean;
 
-  /**
-   * Cast is_headshot to boolean
-   * @param {Death} data
-   * @protected
-   */
-  protected cast(data: DeathPayload) {
-    (this as any).is_headshot = numberStringToBoolean(data.is_headshot);
-    (this as any).is_critical = numberStringToBoolean(data.is_critical);
+  constructor(
+    ...params: ConstructorParameters<typeof PS2Event<PS2Events.Death>>
+  ) {
+    super(...params);
+
+    this.is_headshot = numberStringToBoolean(params[Death.DATA].is_headshot);
+    this.is_critical = numberStringToBoolean(params[Death.DATA].is_critical);
   }
 
   /**
@@ -39,7 +38,7 @@ export class Death extends AttackerEvent<PS2Events.Death> {
     if (this.attacker_character_id === '0') return Kill.RestrictedArea;
     if (this.attacker_character_id === this.character_id) return Kill.Suicide;
 
-    return this.attacker_team === this.team ? Kill.TeamKill : Kill.Normal;
+    return this.attacker_team_id === this.team_id ? Kill.TeamKill : Kill.Normal;
   }
 
   /**
@@ -48,14 +47,9 @@ export class Death extends AttackerEvent<PS2Events.Death> {
    * @return {Faction}
    */
   get character_faction(): Faction {
-    const faction = Death.loadoutFactionMap.get(this.character_loadout_id);
-
-    if (faction === undefined)
-      throw new TypeError(
-        `Unknown character_loadout_id when determining faction: ${this.character_loadout_id}`,
-      );
-
-    return faction;
+    return (
+      Death.loadoutFactionMap.get(this.character_loadout_id) ?? Faction.NONE
+    );
   }
 
   /**

--- a/src/client/events/facility-control.event.ts
+++ b/src/client/events/facility-control.event.ts
@@ -1,6 +1,7 @@
 import { WorldEvent } from './base/world.event';
+import { PS2Events } from '../../stream';
 
-export class FacilityControl extends WorldEvent {
+export class FacilityControl extends WorldEvent<PS2Events.FacilityControl> {
   readonly emit = 'facilityControl';
 
   readonly duration_held: string;

--- a/src/client/events/facility-control.event.ts
+++ b/src/client/events/facility-control.event.ts
@@ -1,15 +1,28 @@
 import { WorldEvent } from './base/world.event';
 import { PS2Events } from '../../stream';
+import { Faction } from '../constants';
+import { PS2Event } from './base/ps2.event';
 
 export class FacilityControl extends WorldEvent<PS2Events.FacilityControl> {
   readonly emit = 'facilityControl';
 
-  readonly duration_held: string;
+  readonly duration_held: number;
   readonly event_name: 'FacilityControl';
   readonly facility_id: string;
-  readonly new_faction_id: string;
-  readonly old_faction_id: string;
+  readonly new_faction_id: Faction;
+  readonly old_faction_id: Faction;
   readonly outfit_id: string;
+
+  constructor(
+    ...params: ConstructorParameters<typeof PS2Event<PS2Events.FacilityControl>>
+  ) {
+    super(...params);
+
+    this.duration_held = Number.parseInt(
+      params[FacilityControl.DATA].duration_held,
+      10,
+    );
+  }
 
   toHash(): string {
     return `FacilityControl:${this.world_id}:${this.timestamp}:${this.facility_id}`;

--- a/src/client/events/gain-experience.event.ts
+++ b/src/client/events/gain-experience.event.ts
@@ -1,6 +1,7 @@
 import { CharacterEvent } from './base/character.event';
+import { PS2Events } from '../../stream';
 
-export class GainExperience extends CharacterEvent {
+export class GainExperience extends CharacterEvent<PS2Events.GainExperience> {
   readonly emit = 'gainExperience';
 
   readonly amount: string;

--- a/src/client/events/gain-experience.event.ts
+++ b/src/client/events/gain-experience.event.ts
@@ -1,15 +1,25 @@
 import { CharacterEvent } from './base/character.event';
 import { PS2Events } from '../../stream';
+import { Faction } from '../constants';
+import { PS2Event } from './base/ps2.event';
 
 export class GainExperience extends CharacterEvent<PS2Events.GainExperience> {
   readonly emit = 'gainExperience';
 
-  readonly amount: string;
+  readonly amount: number;
   readonly event_name: 'GainExperience';
   readonly experience_id: string;
   readonly loadout_id: string;
   readonly other_id: string;
-  readonly team_id: string;
+  readonly team_id: Faction;
+
+  constructor(
+    ...params: ConstructorParameters<typeof PS2Event<PS2Events.GainExperience>>
+  ) {
+    super(...params);
+
+    this.amount = Number.parseInt(params[GainExperience.DATA].amount, 10);
+  }
 
   /**
    * Fetch the character data of other if any

--- a/src/client/events/item-added.event.ts
+++ b/src/client/events/item-added.event.ts
@@ -1,5 +1,6 @@
 import { CharacterEvent } from './base/character.event';
 import { PS2Events } from '../../stream';
+import { PS2Event } from './base/ps2.event';
 
 export class ItemAdded extends CharacterEvent<PS2Events.ItemAdded> {
   readonly emit = 'itemAdded';
@@ -9,13 +10,12 @@ export class ItemAdded extends CharacterEvent<PS2Events.ItemAdded> {
   readonly item_count: number;
   readonly item_id: string;
 
-  /**
-   * Cast item_count to number
-   * @param {ItemAdded} data
-   * @protected
-   */
-  protected cast(data: PS2Events.ItemAdded) {
-    (this as any).item_count = Number.parseInt(data.item_count, 10);
+  constructor(
+    ...params: ConstructorParameters<typeof PS2Event<PS2Events.ItemAdded>>
+  ) {
+    super(...params);
+
+    this.item_count = Number.parseInt(params[ItemAdded.DATA].item_count, 10);
   }
 
   toHash(): string {

--- a/src/client/events/item-added.event.ts
+++ b/src/client/events/item-added.event.ts
@@ -1,12 +1,22 @@
 import { CharacterEvent } from './base/character.event';
+import { PS2Events } from '../../stream';
 
-export class ItemAdded extends CharacterEvent {
+export class ItemAdded extends CharacterEvent<PS2Events.ItemAdded> {
   readonly emit = 'itemAdded';
 
   readonly context: string;
   readonly event_name: 'ItemAdded';
-  readonly item_count: string;
+  readonly item_count: number;
   readonly item_id: string;
+
+  /**
+   * Cast item_count to number
+   * @param {ItemAdded} data
+   * @protected
+   */
+  protected cast(data: PS2Events.ItemAdded) {
+    (this as any).item_count = Number.parseInt(data.item_count, 10);
+  }
 
   toHash(): string {
     return `ItemAdded:${this.character_id}:${this.timestamp}:${this.item_id}`;

--- a/src/client/events/metagame.event.ts
+++ b/src/client/events/metagame.event.ts
@@ -1,6 +1,7 @@
 import { WorldEvent } from './base/world.event';
+import { PS2Events } from '../../stream';
 
-export class MetagameEvent extends WorldEvent {
+export class MetagameEvent extends WorldEvent<PS2Events.MetagameEvent> {
   readonly emit = 'metagameEvent';
 
   readonly event_name: 'MetagameEvent';

--- a/src/client/events/metagame.event.ts
+++ b/src/client/events/metagame.event.ts
@@ -1,18 +1,29 @@
 import { WorldEvent } from './base/world.event';
 import { PS2Events } from '../../stream';
+import { PS2Event } from './base/ps2.event';
 
 export class MetagameEvent extends WorldEvent<PS2Events.MetagameEvent> {
   readonly emit = 'metagameEvent';
 
   readonly event_name: 'MetagameEvent';
   readonly experience_bonus: string;
-  readonly faction_nc: string;
-  readonly faction_tr: string;
-  readonly faction_vs: string;
+  readonly faction_nc: number;
+  readonly faction_tr: number;
+  readonly faction_vs: number;
   readonly metagame_event_id: string;
   readonly metagame_event_state: string;
   readonly metagame_event_state_name: string;
   readonly instance_id: string;
+
+  constructor(
+    ...params: ConstructorParameters<typeof PS2Event<PS2Events.MetagameEvent>>
+  ) {
+    super(...params);
+
+    this.faction_nc = Number.parseFloat(params[MetagameEvent.DATA].faction_nc);
+    this.faction_tr = Number.parseFloat(params[MetagameEvent.DATA].faction_tr);
+    this.faction_vs = Number.parseFloat(params[MetagameEvent.DATA].faction_vs);
+  }
 
   toHash(): string {
     return `MetagameEvent:${this.world_id}:${this.timestamp}`;

--- a/src/client/events/player-facility-capture.event.ts
+++ b/src/client/events/player-facility-capture.event.ts
@@ -1,6 +1,7 @@
 import { CharacterEvent } from './base/character.event';
+import { PS2Events } from '../../stream';
 
-export class PlayerFacilityCapture extends CharacterEvent {
+export class PlayerFacilityCapture extends CharacterEvent<PS2Events.PlayerFacilityCapture> {
   readonly emit = 'playerFacilityCapture';
 
   readonly event_name: 'PlayerFacilityCapture';

--- a/src/client/events/player-facility-defend.event.ts
+++ b/src/client/events/player-facility-defend.event.ts
@@ -1,6 +1,7 @@
 import { CharacterEvent } from './base/character.event';
+import { PS2Events } from '../../stream';
 
-export class PlayerFacilityDefend extends CharacterEvent {
+export class PlayerFacilityDefend extends CharacterEvent<PS2Events.PlayerFacilityDefend> {
   readonly emit = 'playerFacilityDefend';
 
   readonly event_name: 'PlayerFacilityDefend';

--- a/src/client/events/player-login.event.ts
+++ b/src/client/events/player-login.event.ts
@@ -1,6 +1,7 @@
 import { CharacterWorldEvent } from './base/character-world.event';
+import { PS2Events } from '../../stream';
 
-export class PlayerLogin extends CharacterWorldEvent {
+export class PlayerLogin extends CharacterWorldEvent<PS2Events.PlayerLogin> {
   readonly emit = 'playerLogin';
 
   readonly event_name: 'PlayerLogin';

--- a/src/client/events/player-logout.event.ts
+++ b/src/client/events/player-logout.event.ts
@@ -1,6 +1,7 @@
 import { CharacterWorldEvent } from './base/character-world.event';
+import { PS2Events } from '../../stream';
 
-export class PlayerLogout extends CharacterWorldEvent {
+export class PlayerLogout extends CharacterWorldEvent<PS2Events.PlayerLogout> {
   readonly emit = 'playerLogout';
 
   readonly event_name: 'PlayerLogout';

--- a/src/client/events/skill-added.event.ts
+++ b/src/client/events/skill-added.event.ts
@@ -1,6 +1,7 @@
 import { CharacterEvent } from './base/character.event';
+import { PS2Events } from '../../stream';
 
-export class SkillAdded extends CharacterEvent {
+export class SkillAdded extends CharacterEvent<PS2Events.SkillAdded> {
   readonly emit = 'skillAdded';
 
   readonly event_name: 'SkillAdded';

--- a/src/client/events/vehicle-destroy.event.ts
+++ b/src/client/events/vehicle-destroy.event.ts
@@ -1,5 +1,6 @@
 import { Faction, factionMap } from '../constants/ps2.constants';
 import { AttackerEvent } from './base/attacker.event';
+import { PS2Events } from '../../stream';
 
 export enum Destroy {
   Normal,
@@ -9,7 +10,7 @@ export enum Destroy {
   Game,
 }
 
-export class VehicleDestroy extends AttackerEvent {
+export class VehicleDestroy extends AttackerEvent<PS2Events.VehicleDestroy> {
   /**
    * Can be overwritten if necessary
    */
@@ -19,7 +20,7 @@ export class VehicleDestroy extends AttackerEvent {
 
   readonly event_name: 'VehicleDestroy';
   readonly facility_id: string;
-  readonly faction_id: string;
+  readonly faction_id: Faction;
   readonly vehicle_id: string;
 
   /**

--- a/src/client/stream.handler.ts
+++ b/src/client/stream.handler.ts
@@ -8,7 +8,7 @@ import { stringToBoolean } from '../utils/formatters';
 import ServiceStateChanged = CensusMessages.ServiceStateChanged;
 
 import { AchievementEarned } from './events/achievement-earned.event';
-import { BattleRankUpEvent } from './events/battle-rank-up.event';
+import { BattleRankUp } from './events/battle-rank-up.event';
 import { ContinentLock } from './events/continent-lock.event';
 import { ContinentUnlock } from './events/continent-unlock.event';
 import { Death } from './events/death.event';
@@ -111,12 +111,12 @@ export class StreamHandler {
    * @param {PS2Event} event
    * @return {PS2Event}
    */
-  private wrapEvent(event: PS2EventPayload): PS2Event | undefined {
+  private wrapEvent(event: PS2EventPayload): PS2Event<any> | undefined {
     switch (event.event_name) {
       case 'AchievementEarned':
         return new AchievementEarned(this.client, event);
       case 'BattleRankUp':
-        return new BattleRankUpEvent(this.client, event);
+        return new BattleRankUp(this.client, event);
       case 'ContinentLock':
         return new ContinentLock(this.client, event);
       case 'ContinentUnlock':

--- a/src/client/utils/duplicate-filter.ts
+++ b/src/client/utils/duplicate-filter.ts
@@ -31,7 +31,7 @@ export class DuplicateFilter implements StreamFilterContract {
    * @param {PS2Event} event
    * @return {boolean} whether it has been recorded before
    */
-  filter(event: PS2Event): boolean {
+  filter(event: PS2Event<any>): boolean {
     if (this.ignore.includes(event.event_name)) return false;
 
     const hash = event.toHash();


### PR DESCRIPTION
- Fixed name of `BattleRankUp` event class, was `BattleRankUpEvent`;
- More parsing of properties;
- Added `NONE` to `Faction` enum;
- Replaced appropriated types with `Faction` enum;
- Added type parameters to event classes.