### PR TITLE
fix(stream): connecting errors not being handled correctly

### DIFF
--- a/src/client/census.client.ts
+++ b/src/client/census.client.ts
@@ -106,7 +106,7 @@ export class CensusClient extends EventEmitter<ClientEvents> {
    * Doom and destruction, WUHAHAHAHA!
    */
   destroy(): void {
-    this.streamManager?.disconnect();
+    this.streamManager.disconnect();
   }
 
   /**

--- a/src/stream/stream.client.ts
+++ b/src/stream/stream.client.ts
@@ -283,6 +283,7 @@ export class StreamClient extends EventEmitter<StreamClientEvents> {
    */
   private cleanupConnection(): void {
     this.connection?.removeAllListeners();
+    this.connection?.on('error', () => null);
   }
 
   /**


### PR DESCRIPTION
When `destroy` was called before any connection was established it would thrown an uncaught exception, due to the lack of an `error` listener.