### PR TITLE
feat(stream): add browser support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "axios": "1.2.0",
         "eventemitter3": "5.0.0",
+        "isomorphic-ws": "5.0.0",
         "ws": "8.11.0"
       },
       "devDependencies": {
@@ -2607,6 +2608,14 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "node_modules/isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "peerDependencies": {
+        "ws": "*"
+      }
     },
     "node_modules/js-sdsl": {
       "version": "4.2.0",
@@ -6910,6 +6919,12 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isomorphic-ws": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz",
+      "integrity": "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==",
+      "requires": {}
     },
     "js-sdsl": {
       "version": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   "dependencies": {
     "axios": "1.2.0",
     "eventemitter3": "5.0.0",
+    "isomorphic-ws": "5.0.0",
     "ws": "8.11.0"
   },
   "peerDependencies": {

--- a/src/client/command.handler.ts
+++ b/src/client/command.handler.ts
@@ -117,15 +117,12 @@ export class CommandHandler {
       return Promise.reject(new StreamResponseException('Stream is closed'));
 
     return new Promise<T>((resolve, reject) => {
-      this.stream
-        .send(command)
-        .then(() => {
-          queue.enqueue({
-            resolve,
-            reject,
-          });
-        })
-        .catch(reject);
+      this.stream.send(command);
+
+      queue.enqueue({
+        resolve,
+        reject,
+      });
     });
   }
 }

--- a/src/client/stream.handler.ts
+++ b/src/client/stream.handler.ts
@@ -24,6 +24,8 @@ import { SkillAdded } from './events/skill-added.event';
 import { VehicleDestroy } from './events/vehicle-destroy.event';
 import { EventSubscribed } from './types/event-subscription.types';
 
+import nextTick from '../utils/next-tick';
+
 export class StreamHandler {
   /**
    * @param {CensusClient} client
@@ -66,12 +68,12 @@ export class StreamHandler {
     if (!wrapped) return;
 
     if (!this.filter.filter(wrapped)) {
-      setImmediate(() => {
+      nextTick(() => {
         this.client.emit('ps2Event', wrapped);
         this.client.emit(wrapped.emit, wrapped);
       });
     } else {
-      setImmediate(() => {
+      nextTick(() => {
         this.client.emit('duplicate', wrapped);
       });
     }
@@ -83,7 +85,7 @@ export class StreamHandler {
    * @param subscription
    */
   private handleSubscription(subscription: EventSubscribed): void {
-    setImmediate(() => {
+    nextTick(() => {
       this.client.emit('subscribed', subscription);
     });
   }
@@ -99,7 +101,7 @@ export class StreamHandler {
     if (id) {
       const online = stringToBoolean(state.online);
 
-      setImmediate(() => {
+      nextTick(() => {
         this.client.emit('serviceState', id, online, state.detail);
       });
     }

--- a/src/client/utils/decaying-set.ts
+++ b/src/client/utils/decaying-set.ts
@@ -5,7 +5,7 @@ export class DecayingSet<T> {
 
   private readonly set: Array<Set<T>>;
 
-  private timeout: Timeout;
+  private timeout: Timeout | number;
 
   constructor(private readonly partitions: number, decay: number) {
     this.set = [];
@@ -19,7 +19,7 @@ export class DecayingSet<T> {
       this.set[this.index].clear();
     }, decay / partitions);
 
-    this.timeout.unref();
+    this.timeout.unref && this.timeout.unref();
   }
 
   add(value: T): this {

--- a/src/stream/stream.client.ts
+++ b/src/stream/stream.client.ts
@@ -291,8 +291,9 @@ export class StreamClient extends EventEmitter<StreamClientEvents> {
    * If a connection exists cleanup listeners
    */
   private cleanupConnection(): void {
-    this.connection?.removeAllListeners();
-    this.connection?.on('error', () => null);
+    if (!this.connection) return;
+    this.connection.removeAllListeners();
+    this.connection.onerror = () => null;
   }
 
   /**

--- a/src/stream/stream.client.ts
+++ b/src/stream/stream.client.ts
@@ -1,5 +1,6 @@
 import { EventEmitter } from 'eventemitter3';
-import WebSocket, { ClientOptions, Data } from 'ws';
+import { ClientOptions, Data } from 'ws';
+import WebSocket from 'isomorphic-ws';
 import { PS2Environment } from '../types/ps2.options';
 import { CensusMessage } from './types/messages.types';
 import { CensusCommand } from './types/command.types';

--- a/src/stream/stream.client.ts
+++ b/src/stream/stream.client.ts
@@ -8,6 +8,8 @@ import { StreamDestroyedException } from './exceptions/stream-destroyed.exceptio
 import { StreamClosedException } from './exceptions/stream-closed.exception';
 import Timeout = NodeJS.Timeout;
 
+import nextTick from '../utils/next-tick';
+
 enum State {
   IDLE,
   CONNECTING,
@@ -251,7 +253,7 @@ export class StreamClient extends EventEmitter<StreamClientEvents> {
       this.acknowledgeHeartbeat();
     }
 
-    setImmediate(() => {
+    nextTick(() => {
       this.emit('message', data);
     });
   }

--- a/src/stream/stream.client.ts
+++ b/src/stream/stream.client.ts
@@ -203,12 +203,11 @@ export class StreamClient extends EventEmitter<StreamClientEvents> {
   private onMessage(event: WebSocket.MessageEvent): void {
     const { data } = event;
 
-    let parse: (data: any) => CensusMessage;
-    if (typeof data === 'string') {
-      parse = (data: string) => JSON.parse(data);
-    } else if (data instanceof Buffer) {
-      parse = (data: Buffer) => JSON.parse(data.toString());
-    } else {
+    const isExpectedFormat =
+      typeof data === 'string' ||
+      (typeof Buffer !== 'undefined' && data instanceof Buffer);
+
+    if (!isExpectedFormat) {
       this.emit(
         'warn',
         new TypeError(`Received data in unexpected format: ${data}`),
@@ -217,7 +216,7 @@ export class StreamClient extends EventEmitter<StreamClientEvents> {
     }
 
     try {
-      const parsed = parse(data);
+      const parsed = JSON.parse(data.toString());
 
       this.onPackage(parsed);
     } catch (err) {

--- a/src/stream/stream.client.ts
+++ b/src/stream/stream.client.ts
@@ -410,17 +410,11 @@ export class StreamClient extends EventEmitter<StreamClientEvents> {
   /**
    * @param data
    */
-  send(data: CensusCommand): Promise<void> {
-    return new Promise((resolve, reject) => {
-      if (!this.connection) {
-        reject(new Error(`Connection not available`));
-        return;
-      }
+  send(data: CensusCommand): void {
+    if (!this.connection) throw new Error(`Connection not available`);
 
-      this.connection.send(JSON.stringify(data), err => {
-        if (err) reject(err);
-        else resolve();
-      });
+    this.connection.send(JSON.stringify(data), err => {
+      if (err) this.emit('error', err);
     });
   }
 }

--- a/src/stream/stream.client.ts
+++ b/src/stream/stream.client.ts
@@ -294,7 +294,7 @@ export class StreamClient extends EventEmitter<StreamClientEvents> {
    */
   private cleanupConnection(): void {
     if (!this.connection) return;
-    this.connection.removeAllListeners();
+    this.connection.onopen = this.connection.onclose = this.connection.onmessage = null;
     this.connection.onerror = () => null;
   }
 

--- a/src/utils/next-tick.ts
+++ b/src/utils/next-tick.ts
@@ -1,0 +1,14 @@
+// setImmediate is not available in most browsers, and process.nextTick is
+// preferred in Node.
+export default function nextTick(
+  callback: (...args: any[]) => void,
+  ...args: any[]
+): void {
+  if (typeof process !== 'undefined' && process.nextTick) {
+    process.nextTick(callback, ...args);
+  } else if (typeof setImmediate !== 'undefined') {
+    setImmediate(callback, ...args);
+  } else {
+    setTimeout(callback, 0, ...args);
+  }
+}


### PR DESCRIPTION
Resolves #55 

- [x] Add [`isomorphic-ws` ](https://www.npmjs.com/package/isomorphic-ws)
- [x] Fix browser-exclusive issues
  - ~~[x] Fix issue with Axios~~
  - [x] Fix issue with `Timeout` being Node-only
  - [x] Fix issue with `setImmediate` being Node-only
  - [x] Fix race condition with Queue
- [x] Pass lint checks
- [x] Confirm working in Node.js and browser

Was hoping to use this in the browser after really appreciating it in Node.js. I've added the latest version of `isomorphic-ws` as suggested in #55.

This doesn't seem to quite work yet (or might be a quirk of my setup), ~~as I now get an error around how `Axios` is being included/used in the `CensusClient`'s `RestClient`'s constructor. It seems like the default import ends up being a string of the path to the `cjs` import, rather than an import matching the `AxiosStatic` interface.~~

### ~~Error~~
```
Uncaught TypeError: axios_1.default.create is not a function
    at new RestClient (rest.client.js:30:1)
    at new CensusClient (census.client.js:28:1)
```

<img width="438" alt="image" src="https://user-images.githubusercontent.com/107798/205515679-cc7d1d0f-2e05-4ebf-80a4-25e4f66bb360.png">

<img width="335" alt="image" src="https://user-images.githubusercontent.com/107798/205515724-9e2778c2-db69-4894-b721-1e8ba8104b2a.png">