### PR TITLE
feat(stream): removed echo type from emitted census messages type

### DIFF
--- a/.changeset/shaggy-houses-design.md
+++ b/.changeset/shaggy-houses-design.md
@@ -1,0 +1,5 @@
+---
+'ps2census': minor
+---
+
+To improve the typing of messages received on the stream client echo is ignored. It will be up to the user to override the type using `CensusMessage`..

--- a/src/client/command.handler.ts
+++ b/src/client/command.handler.ts
@@ -27,15 +27,16 @@ export class CommandHandler {
   }
 
   private prepareListeners(): void {
-    this.stream.on('message', message => {
+    this.stream.on('message', msg => {
       if (
-        message.service === 'event' &&
-        message.type == 'serviceMessage' &&
-        'recent_character_id_count' in message.payload
+        'service' in msg &&
+        msg.service === 'event' &&
+        msg.type == 'serviceMessage' &&
+        'recent_character_id_count' in msg.payload
       ) {
-        this.recentCharacterQueue.dequeue().resolve(message.payload);
-      } else if (message.subscription) {
-        this.subscriptionQueue.dequeue().resolve(message.subscription);
+        this.recentCharacterQueue.dequeue().resolve(msg.payload);
+      } else if ('subscription' in msg) {
+        this.subscriptionQueue.dequeue().resolve(msg.subscription);
       }
     });
 

--- a/src/client/stream.handler.ts
+++ b/src/client/stream.handler.ts
@@ -5,7 +5,6 @@ import { CensusClient } from './census.client';
 import { StreamClient } from '../stream/stream.client';
 import { CensusMessages } from '../stream/types/messages.types';
 import { stringToBoolean } from '../utils/formatters';
-import ServiceStateChanged = CensusMessages.ServiceStateChanged;
 
 import { AchievementEarned } from './events/achievement-earned.event';
 import { BattleRankUp } from './events/battle-rank-up.event';
@@ -24,6 +23,7 @@ import { VehicleDestroy } from './events/vehicle-destroy.event';
 import { EventSubscribed } from './types/event-subscription.types';
 
 import nextTick from '../utils/next-tick';
+import ServiceStateChanged = CensusMessages.ServiceStateChanged;
 
 export class StreamHandler {
   /**
@@ -40,18 +40,18 @@ export class StreamHandler {
   }
 
   private prepareListeners(): void {
-    this.stream.on('message', message => {
-      if (message.service === 'event') {
-        switch (message.type) {
+    this.stream.on('message', msg => {
+      if ('service' in msg && msg.service === 'event') {
+        switch (msg.type) {
           case 'serviceStateChanged':
-            this.handleServerStateChanged(message);
+            this.handleServerStateChanged(msg);
             break;
           case 'serviceMessage':
-            this.handleEvent(message.payload);
+            if ('event_name' in msg.payload) this.handleEvent(msg.payload);
             break;
         }
-      } else if (message.subscription) {
-        this.handleSubscription(message.subscription);
+      } else if ('subscription' in msg && msg.subscription) {
+        this.handleSubscription(msg.subscription);
       }
     });
   }

--- a/src/client/stream.handler.ts
+++ b/src/client/stream.handler.ts
@@ -50,7 +50,7 @@ export class StreamHandler {
             if ('event_name' in msg.payload) this.handleEvent(msg.payload);
             break;
         }
-      } else if ('subscription' in msg && msg.subscription) {
+      } else if ('subscription' in msg) {
         this.handleSubscription(msg.subscription);
       }
     });

--- a/src/stream/stream.client.ts
+++ b/src/stream/stream.client.ts
@@ -2,7 +2,10 @@ import { EventEmitter } from 'eventemitter3';
 import { ClientOptions } from 'ws';
 import WebSocket from 'isomorphic-ws';
 import { PS2Environment } from '../types/ps2.options';
-import { CensusMessage } from './types/messages.types';
+import {
+  CensusMessage,
+  CensusMessageWithoutEcho,
+} from './types/messages.types';
 import { CensusCommand } from './types/command.types';
 import { StreamDestroyedException } from './exceptions/stream-destroyed.exception';
 import { StreamClosedException } from './exceptions/stream-closed.exception';
@@ -32,7 +35,7 @@ type StreamClientEvents = {
   error: (err: Error) => void;
   warn: (err: Error) => void;
   debug: (info: string) => void;
-  message: (message: CensusMessage) => void;
+  message: (message: CensusMessageWithoutEcho) => void;
 };
 
 export class StreamClient extends EventEmitter<StreamClientEvents> {
@@ -237,7 +240,7 @@ export class StreamClient extends EventEmitter<StreamClientEvents> {
    *
    * @param {CensusMessage} data
    */
-  private onPackage(data: CensusMessage): void {
+  private onPackage(data: CensusMessageWithoutEcho): void {
     if (
       'service' in data &&
       data.service === 'push' &&

--- a/src/stream/types/messages.types.ts
+++ b/src/stream/types/messages.types.ts
@@ -63,14 +63,15 @@ export namespace CensusMessages {
     };
   };
 
-  export type Echo = any;
+  export type Echo = unknown;
 }
 
-export type CensusMessage =
+export type CensusMessageWithoutEcho =
   | CensusMessages.ConnectionStateChanged
   | CensusMessages.ServiceStateChanged
   | CensusMessages.Heartbeat
   | CensusMessages.ServiceMessage
   | CensusMessages.Subscription
-  | CensusMessages.Help
-  | CensusMessages.Echo;
+  | CensusMessages.Help;
+
+export type CensusMessage = CensusMessageWithoutEcho | CensusMessages.Echo;


### PR DESCRIPTION
Echo downgrades the `CensusMessage` type to `any`/`unknown`. This isn't ideal as it negates all type safety. Hence we exclude the echo type. The user can always override the type, like:
```ts
streamClient.on('message', (msg: Stream.CensusMessage) => {
  // Do something
});
```
Caution is still advised when implementing echo messages. Creating a custom types for any echo messages is highly recommended which can then be combined in a union with `CensusMessageWithoutEcho` message type.