### PR TITLE
fix(client): fix terms expression rendering

### DIFF
--- a/.changeset/nasty-buttons-tell.md
+++ b/.changeset/nasty-buttons-tell.md
@@ -1,0 +1,5 @@
+---
+"ps2census": patch
+---
+
+fix(client): fix terms expression rendering

--- a/src/rest/get.query.ts
+++ b/src/rest/get.query.ts
@@ -222,7 +222,7 @@ export class GetQuery<C extends CollectionNames, R = Format<C>> {
         // A term with a list of values is added multiple times due to the fact that Census is weird.
         if (join.terms)
           str += `^terms:${Object.entries(join.terms)
-            .map((k, v) =>
+            .map(([k, v]) =>
               Array.isArray(v)
                 ? v.map(sv => `${k}=${sv}`).join('`')
                 : `${k}=${v}`,


### PR DESCRIPTION
fixes small bug in terms rendering which causes a garbled terms clause do to a missing destructuring call:

For example, before this fix `{... terms: {world_id: "19"}` produces `terms:world_id,19=0` instead of `terms:world_id=19`.